### PR TITLE
release into sibling repo instead of to npm

### DIFF
--- a/scripts/getPackageNames.js
+++ b/scripts/getPackageNames.js
@@ -3,6 +3,7 @@ const path = require('path')
 
 exports.PACKAGES_SRC_DIR = './src/packages'
 exports.PACKAGES_OUT_DIR = './lib/packages'
+exports.PACKAGES_RELEASE_DIR = '../recompose'
 
 let names
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6793,7 +6793,7 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-upath@^1.0.0, upath@^1.0.5, upath@^1.1.0:
+upath@^1.0.0, upath@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 


### PR DESCRIPTION
Since we don't want to publish our fork to npm, release into the sibling `recompose` repo. 